### PR TITLE
fix: pin google-api-core>=1.14.0, update format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,70 @@
-"""A setup module for the GAPIC Dialogflow API library.
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-See:
-https://packaging.python.org/en/latest/distributing.html
-https://github.com/pypa/sampleproject
-"""
-
-from setuptools import setup, find_packages
 import io
+import os
 
-install_requires = [
-    "google-api-core[grpc]<2.0.0dev,>=0.1.4",
+import setuptools
+
+name = "dialogflow"
+description = "Client library for the Dialogflow API"
+version = "0.6.0"
+release_status = "Development Status :: 4 - Beta"
+dependencies = [
+    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
     "googleapis-common-protos[grpc]>=1.5.2, <2.0dev",
 ]
 
-with io.open("README.rst", "r", encoding="utf-8") as readme_file:
-    long_description = readme_file.read()
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+readme_filename = os.path.join(package_root, "README.rst")
+with io.open(readme_filename, encoding="utf-8") as readme_file:
+    readme = readme_file.read()
+
+packages = setuptools.find_packages()
 
 setup(
+<<<<<<< HEAD
     name="dialogflow",
     version="0.7.0",
+=======
+    name=name,
+    version=version,
+    description=description,
+    long_description=readme,
+>>>>>>> fix: pin google-api-core version, update format
     author="Google LLC",
     author_email="googleapis-packages@google.com",
+    license="Apache 2.0",
+    url="https://github.com/dialogflow/dialogflow-python-client-v2",
     classifiers=[
-        "Intended Audience :: Developers",
-        "Development Status :: 4 - Beta",
+        release_status,
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
     ],
-    description="Client library for the Dialogflow API",
-    include_package_data=True,
-    long_description=long_description,
-    install_requires=install_requires,
+    platforms="Posix; MacOS X; Windows",
+    packages=packages,
+    install_requires=dependencies,
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*",
-    license="Apache 2.0",
-    packages=find_packages(),
-    url="https://github.com/dialogflow/dialogflow-python-client-v2",
+    include_package_data=True,
+    zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ version = "0.6.0"
 release_status = "Development Status :: 4 - Beta"
 dependencies = [
     "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
-    "googleapis-common-protos[grpc]>=1.5.2, <2.0dev",
 ]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -35,15 +34,8 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 packages = setuptools.find_packages()
 
 setup(
-<<<<<<< HEAD
     name="dialogflow",
     version="0.7.0",
-=======
-    name=name,
-    version=version,
-    description=description,
-    long_description=readme,
->>>>>>> fix: pin google-api-core version, update format
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     license="Apache 2.0",

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,7 @@ name = "dialogflow"
 description = "Client library for the Dialogflow API"
 version = "0.6.0"
 release_status = "Development Status :: 4 - Beta"
-dependencies = [
-    "google-api-core[grpc] >= 1.14.0, < 2.0.0dev",
-]
+dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
@@ -33,7 +31,7 @@ with io.open(readme_filename, encoding="utf-8") as readme_file:
 
 packages = setuptools.find_packages()
 
-setup(
+setuptools.setup(
     name="dialogflow",
     version="0.7.0",
     author="Google LLC",


### PR DESCRIPTION
Client Options is only available starting in 1.13.0. The other libraries are being released with api_core pinned to >=1.14.0 for googleapis-common-protos. See https://github.com/googleapis/google-cloud-python/issues/8686